### PR TITLE
disable browser default behaviors for true native app feels

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,16 +1,20 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/public/icons/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/public/icons/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/public/icons/favicon-16x16.png">
-    <link rel="manifest" href="/public/icons/site.webmanifest">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>tracking-app</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/public/icons/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/public/icons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/public/icons/favicon-16x16.png">
+  <link rel="manifest" href="/public/icons/site.webmanifest">
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+  <title>tracking-app</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,12 +5,16 @@
 *::before,
 *::after {
   box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  /* Removes the tap flash */
 }
 
 html,
 body {
   height: 100%;
   scrollbar-gutter: stable;
+  overscroll-behavior: none;
+  /* Stops ALL bouncing, pull-to-refresh, and swipe-navigation */
   /* Prevents layout shift between pages with/without scrollbars */
 }
 
@@ -19,11 +23,25 @@ body {
   font-family: var(--pm-font);
   background: var(--pm-bg);
   color: var(--pm-text);
+
+  /* Stop long-press context menus and text selection */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+/* Allow text selection inside inputs */
+input,
+textarea {
+  -webkit-user-select: auto;
+  user-select: auto;
 }
 
 img {
   max-width: 100%;
   display: block;
+  -webkit-user-drag: none;
+  /* Prevents ghost dragging of images */
 }
 
 /* Fix Leaflet tiles disappearing due to global max-width */


### PR DESCRIPTION
-Disabled pinch-to-zoom and scaling: Updated
index.html
 to ensure your app always behaves visually like a native app by restricting the viewport metadata and adding viewport-fit=cover.

-Applied native-feel CSS reset: Updated
src/styles/global.css
 with properties that disable:
Text selection and ghost image dragging.
The translucent tap highlight (flash) on inputs and buttons. Long-press context menus.
Pull-to-refresh, screen bouncing, and horizontal swipe-navigation ("overscroll" behavior).